### PR TITLE
Add clickable screenshot gallery

### DIFF
--- a/generic.html
+++ b/generic.html
@@ -9,8 +9,67 @@
 		<title>Projects</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+                <link rel="stylesheet" href="assets/css/main.css" />
+                <noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+                <style>
+                        .gallery {
+                                display: flex;
+                                flex-wrap: wrap;
+                                gap: 1rem;
+                                justify-content: center;
+                        }
+                        .gallery img {
+                                max-width: 200px;
+                                cursor: pointer;
+                                border-radius: 4px;
+                        }
+                        .modal {
+                                display: none;
+                                position: fixed;
+                                z-index: 1000;
+                                left: 0;
+                                top: 0;
+                                width: 100%;
+                                height: 100%;
+                                overflow: auto;
+                                background-color: rgba(0,0,0,0.8);
+                        }
+                        .modal-content {
+                                margin: auto;
+                                display: block;
+                                max-width: 80%;
+                                max-height: 80%;
+                        }
+                        .close {
+                                position: absolute;
+                                top: 10px;
+                                right: 25px;
+                                color: #fff;
+                                font-size: 35px;
+                                font-weight: bold;
+                                cursor: pointer;
+                        }
+                        .prev, .next {
+                                cursor: pointer;
+                                position: absolute;
+                                top: 50%;
+                                padding: 16px;
+                                color: #fff;
+                                font-weight: bold;
+                                font-size: 30px;
+                                user-select: none;
+                                -webkit-user-select: none;
+                        }
+                        .prev { left: 10px; }
+                        .next { right: 10px; }
+                        #caption {
+                                margin: auto;
+                                display: block;
+                                text-align: center;
+                                color: #fff;
+                                padding: 10px 0;
+                        }
+                </style>
 	</head>
 	<body class="is-preload">
 
@@ -52,9 +111,21 @@
 								<h4>Feugiat aliquam</h4>
 								<p>Nam sapien ante, varius in pulvinar vitae, rhoncus id massa. Donec varius ex in mauris ornare, eget euismod urna egestas. Etiam lacinia tempor ipsum, sodales porttitor justo. Aliquam dolor quam, semper in tortor eu, volutpat efficitur quam. Fusce nec fermentum nisl. Aenean erat diam, tempus aliquet erat.</p>
 
-								<p>Etiam iaculis nulla ipsum, et pharetra libero rhoncus ut. Phasellus rutrum cursus velit, eget condimentum nunc blandit vel. In at pulvinar lectus. Morbi diam ante, vulputate et imperdiet eget, fermentum non dolor. Ut eleifend sagittis tincidunt. Sed viverra commodo mi, ac rhoncus justo. Duis neque ligula, elementum ut enim vel, posuere finibus justo. Vivamus facilisis maximus nibh quis pulvinar. Quisque hendrerit in ipsum id tellus facilisis fermentum. Proin mauris dui, at vestibulum sit amet, auctor bibendum neque.</p>
+                                                                <p>Etiam iaculis nulla ipsum, et pharetra libero rhoncus ut. Phasellus rutrum cursus velit, eget condimentum nunc blandit vel. In at pulvinar lectus. Morbi diam ante, vulputate et imperdiet eget, fermentum non dolor. Ut eleifend sagittis tincidunt. Sed viverra commodo mi, ac rhoncus justo. Duis neque ligula, elementum ut enim vel, posuere finibus justo. Vivamus facilisis maximus nibh quis pulvinar. Quisque hendrerit in ipsum id tellus facilisis fermentum. Proin mauris dui, at vestibulum sit amet, auctor bibendum neque.</p>
 
-							</div>
+                                                                <hr />
+                                                                <h2>Screenshots</h2>
+                                                                <div id="screenshot-gallery" class="gallery"></div>
+
+                                                                <div id="imgModal" class="modal">
+                                                                        <span class="close">&times;</span>
+                                                                        <img class="modal-content" id="modalImage" />
+                                                                        <a class="prev">&#10094;</a>
+                                                                        <a class="next">&#10095;</a>
+                                                                        <div id="caption"></div>
+                                                                </div>
+
+                                                        </div>
 						</section>
 					</article>
 
@@ -76,7 +147,69 @@
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+                        <script src="assets/js/main.js"></script>
+                        <script>
+                                const screenshotFiles = [
+                                        "Screenshot 2025-08-02 120321.png",
+                                        "Screenshot 2025-08-02 120336.png",
+                                        "Screenshot 2025-08-02 120355.png",
+                                        "Screenshot 2025-08-02 120406.png",
+                                        "Screenshot 2025-08-02 122439.png",
+                                        "Screenshot 2025-08-02 122452.png",
+                                        "Screenshot 2025-08-02 122501.png"
+                                ];
+                                const gallery = document.getElementById("screenshot-gallery");
+                                screenshotFiles.forEach((file, index) => {
+                                        const img = document.createElement("img");
+                                        img.src = "images/" + encodeURIComponent(file);
+                                        img.alt = "Screenshot " + (index + 1);
+                                        img.dataset.index = index;
+                                        gallery.appendChild(img);
+                                });
+                                const modal = document.getElementById("imgModal");
+                                const modalImg = document.getElementById("modalImage");
+                                const captionText = document.getElementById("caption");
+                                let currentIndex = 0;
+                                function showImage(index) {
+                                        currentIndex = (index + screenshotFiles.length) % screenshotFiles.length;
+                                        modalImg.src = "images/" + encodeURIComponent(screenshotFiles[currentIndex]);
+                                        captionText.textContent = "Screenshot " + (currentIndex + 1);
+                                }
+                                gallery.addEventListener("click", (e) => {
+                                        if (e.target.tagName === "IMG") {
+                                                showImage(Number(e.target.dataset.index));
+                                                modal.style.display = "block";
+                                        }
+                                });
+                                function closeModal() {
+                                        modal.style.display = "none";
+                                }
+                                document.querySelector(".close").addEventListener("click", closeModal);
+                                document.querySelector(".prev").addEventListener("click", (e) => {
+                                        e.stopPropagation();
+                                        showImage(currentIndex - 1);
+                                });
+                                document.querySelector(".next").addEventListener("click", (e) => {
+                                        e.stopPropagation();
+                                        showImage(currentIndex + 1);
+                                });
+                                modal.addEventListener("click", (e) => {
+                                        if (e.target === modal) {
+                                                closeModal();
+                                        }
+                                });
+                                document.addEventListener("keydown", (e) => {
+                                        if (modal.style.display === "block") {
+                                                if (e.key === "ArrowRight") {
+                                                        showImage(currentIndex + 1);
+                                                } else if (e.key === "ArrowLeft") {
+                                                        showImage(currentIndex - 1);
+                                                } else if (e.key === "Escape") {
+                                                        closeModal();
+                                                }
+                                        }
+                                });
+                        </script>
 
 	</body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS, HTML, and JS to display screenshots in a gallery with modal popups
- add navigation arrows and keyboard support to cycle screenshots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9ae5a2e0832fbce033eee96b2245